### PR TITLE
Rotary encoder

### DIFF
--- a/src/assets/toolbox_adv.xml
+++ b/src/assets/toolbox_adv.xml
@@ -242,6 +242,18 @@
 				</block>
 			</value>
 		</block>
+        <block type="coderbot_adv_move_distance">
+			<value name="SPEED">
+				<block type="math_number">
+					<field name="NUM">100</field>
+				</block>
+			</value>
+			<value name="DISTANCE">
+				<block type="math_number">
+					<field name="NUM">1000</field>
+				</block>
+			</value>
+		</block>
 		<block type="coderbot_adv_motor">
 			<value name="SPEED_LEFT">
 				<block type="math_number">

--- a/src/assets/toolbox_adv.xml
+++ b/src/assets/toolbox_adv.xml
@@ -243,6 +243,13 @@
 			</value>
 		</block>
         <block type="coderbot_adv_move_distance">
+			<value name="DISTANCE">
+				<block type="math_number">
+					<field name="NUM">1000</field>
+				</block>
+			</value>
+		</block>
+        <block type="coderbot_adv_move_speed_distance">
 			<value name="SPEED">
 				<block type="math_number">
 					<field name="NUM">100</field>

--- a/src/components/Activity.vue
+++ b/src/components/Activity.vue
@@ -756,7 +756,8 @@ export default {
 					Blockly.Python.ORDER_NONE) || '\'\'';
 				return sbsPrefix + 'get_bot().sleep(' + elapse + ')\n';
 			};
-
+            
+            // muovi bot [direzione] a velocità [velcità] per [tempo] 
 			Blockly.Blocks['coderbot_adv_move'] = {
 				// Block for moving forward.
 				init: function() {
@@ -811,6 +812,55 @@ export default {
 				var code = sbsPrefix + "get_bot()." + action + "(speed=" + speed + ", elapse=" + elapse + ")\n";
 				return code;
 			};
+            
+            // muovi bot [direzione] per [distanza] metri
+			Blockly.Blocks['coderbot_adv_move_distance'] = {
+				// Block for moving forward.
+				init: function() {
+					var ACTIONS = [
+						[Blockly.Msg.CODERBOT_MOVE_ADV_TIP_FORWARD, 'FORWARD'],
+						[Blockly.Msg.CODERBOT_MOVE_ADV_TIP_BACKWARD, 'BACKWARD']
+					]
+					this.setHelpUrl('http://code.google.com/p/blockly/wiki/Move');
+					this.setColour(40);
+
+					this.appendDummyInput("ACTION")
+						.appendField(Blockly.Msg.CODERBOT_MOVE_ADV_MOVE)
+						.appendField(new Blockly.FieldDropdown(ACTIONS), 'ACTION');
+					this.appendValueInput('DISTANCE')
+						.setCheck('Number')
+						.appendField(Blockly.Msg.CODERBOT_MOVE_ADV_ELAPSE)
+                        .appendField(Blockly.Msg.MEASURE_UNIT);
+					this.setInputsInline(true);
+					// Assign 'this' to a variable for use in the tooltip closure below.
+					var thisBlock = this;
+					this.setTooltip(function() {
+						var mode = thisBlock.getFieldValue('ACTION');
+						var TOOLTIPS = {
+							FORWARD: Blockly.Msg.CODERBOT_MOVE_ADV_TIP_FORWARD,
+							BACKWARD: Blockly.Msg.CODERBOT_MOVE_ADV_TIP_BACKWARD
+						};
+						return TOOLTIPS[mode] + Blockly.Msg.CODERBOT_MOVE_ADV_TIP_TAIL;
+					});
+					this.setPreviousStatement(true);
+					this.setNextStatement(true);
+				}
+			};
+
+			Blockly.Python['coderbot_adv_move_distance'] = function(block) {
+				// Generate Python for moving forward.
+				var OPERATORS = {
+					FORWARD: ['forward'],
+					BACKWARD: ['backward']
+				};
+				var tuple = OPERATORS[block.getFieldValue('ACTION')];
+				var action = tuple[0];
+				var speed = 100;
+				var distance = Blockly.Python.valueToCode(block, 'DISTANCE', Blockly.Python.ORDER_NONE);
+				var code = sbsPrefix + "get_bot()." + action + "(speed=" + speed + ", distance=" + distance + ")\n";
+				return code;
+			};
+
 
 			Blockly.Blocks['coderbot_motion_move'] = {
 				// Block for moving forward.

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -271,7 +271,7 @@
                                                     <v-layout row wrap justify-center>
                                                         <!-- switch -->
                                                         <v-flex xs12 offset-md2 md5>
-                                                            <v-switch label="Sonar" value="sonar" v-model="checkedTests" color="#f45525"></v-switch>
+                                                            <v-switch label="Sonar" value="sonar" v-model="checkedTests" color="orange"></v-switch>
                                                         </v-flex>
                                                         <!-- button state -->
                                                         <v-flex xs12 md4>
@@ -302,14 +302,14 @@
                                                     <v-layout row wrap justify-center>
                                                         <!-- switch -->
                                                         <v-flex xs12 offset-md2 md5>
-                                                            <v-switch label="Motors" value="motors" v-model="checkedTests" color="#f45525">
+                                                            <v-switch label="Motors" value="motors" v-model="checkedTests" color="orange">
                                                             </v-switch>
                                                         </v-flex>
                                                         <!-- button state -->
                                                         <v-flex xs12 md4>
                                                             <span v-if="cb.logs.test != null && cb.logs.test.motors != 0"> 
                                                                 <!-- passed -->
-                                                                <span v-if="cb.logs.test.motor== 1"> 
+                                                                <span v-if="cb.logs.test.motors== 1"> 
                                                                     <v-btn @click="runTests" slot="activator" color="green" dark>
                                                                         <v-icon>fas fa-check</v-icon> Passed
                                                                     </v-btn>
@@ -334,7 +334,7 @@
                                                     <v-layout row wrap justify-center>
                                                         <!-- switch -->
                                                         <v-flex xs12 offset-md2 md5>
-                                                            <v-switch label="Speaker" value="speaker" v-model="checkedTests" color="#f45525">
+                                                            <v-switch label="Speaker" value="speaker" v-model="checkedTests" color="orange">
                                                             </v-switch>
                                                         </v-flex>
                                                         <!-- button state -->
@@ -366,7 +366,7 @@
                                                     <v-layout row wrap justify-center>
                                                         <!-- switch -->
                                                         <v-flex xs12 offset-md2 md5>
-                                                            <v-switch label="OCR" value="ocr" v-model="checkedTests" color="#f45525">
+                                                            <v-switch label="OCR" value="ocr" v-model="checkedTests" color="orange">
                                                             </v-switch>
                                                         </v-flex>
                                                         <!-- button state -->
@@ -405,14 +405,14 @@
                                                            block
                                                            @click="runTests"
                                                            slot="activator" 
-                                                           color="error" 
+                                                           color="orange" 
                                                            dark>
-                                                        <v-icon>fas fa-share-square</v-icon> Run tests
+                                                        <v-icon>fas fa-running</v-icon> Run tests
                                                     </v-btn>
                                                     <v-btn v-else
                                                            block
                                                            disabled>
-                                                        <v-icon>fas fa-share-square</v-icon> Running tests...
+                                                        <v-icon>fas fa-ellipsis-h</v-icon> Running tests...
                                                     </v-btn>
                                                     <!-- DEBUG
                                                        Running test: {{ cb.logs.runningTest }}

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -267,17 +267,156 @@
                                             
 											<div class="cardContent">
 												<div id='test_array'>
-                                                        <v-switch label="Motors" value="motors" v-model="checkedTests" color="#f45525"></v-switch>
-                                                        <v-switch label="Sonar" value="sonar" v-model="checkedTests" color="#f45525"></v-switch>
-                                                        <v-switch label="Speaker" value="speaker" v-model="checkedTests" color="#f45525"></v-switch>
-                                                        <v-switch label="OCR" value="ocr" v-model="checkedTests" color="#f45525"></v-switch>
-                                                    <span>Checked names: {{ checkedTests }}</span>
+                                                    <!-- SONAR -->
+                                                    <v-layout row wrap justify-center>
+                                                        <!-- switch -->
+                                                        <v-flex xs12 offset-md2 md5>
+                                                            <v-switch label="Sonar" value="sonar" v-model="checkedTests" color="#f45525"></v-switch>
+                                                        </v-flex>
+                                                        <!-- button state -->
+                                                        <v-flex xs12 md4>
+                                                            <span v-if="cb.logs.test != null && cb.logs.test.sonar != 0"> 
+                                                                <!-- passed -->
+                                                                <span v-if="cb.logs.test.sonar == 1"> 
+                                                                    <v-btn @click="runTests" slot="activator" color="green" dark>
+                                                                        <v-icon>fas fa-check</v-icon> Passed
+                                                                    </v-btn>
+                                                                </span>
+                                                                <!-- failed -->
+                                                                <span v-else> 
+                                                                    <v-btn @click="runTests" slot="activator" color="red" dark>
+                                                                        <v-icon>fas fa-times</v-icon> Failed
+                                                                    </v-btn>
+                                                                </span>
+                                                            </span>
+                                                            <!-- not tested -->
+                                                            <span v-else> 
+                                                                <v-btn @click="runTests" slot="activator" color="grey" dark>
+                                                                    <v-icon>fas fa-question</v-icon> Not tested
+                                                                </v-btn>
+                                                            </span>
+                                                        </v-flex>
+                                                    </v-layout>
+                                                    
+                                                    <!-- MOTORS -->
+                                                    <v-layout row wrap justify-center>
+                                                        <!-- switch -->
+                                                        <v-flex xs12 offset-md2 md5>
+                                                            <v-switch label="Motors" value="motors" v-model="checkedTests" color="#f45525">
+                                                            </v-switch>
+                                                        </v-flex>
+                                                        <!-- button state -->
+                                                        <v-flex xs12 md4>
+                                                            <span v-if="cb.logs.test != null && cb.logs.test.motors != 0"> 
+                                                                <!-- passed -->
+                                                                <span v-if="cb.logs.test.motor== 1"> 
+                                                                    <v-btn @click="runTests" slot="activator" color="green" dark>
+                                                                        <v-icon>fas fa-check</v-icon> Passed
+                                                                    </v-btn>
+                                                                </span>
+                                                                <!-- failed -->
+                                                                <span v-else> 
+                                                                    <v-btn @click="runTests" slot="activator" color="red" dark>
+                                                                        <v-icon>fas fa-times</v-icon> Failed
+                                                                    </v-btn>
+                                                                </span>
+                                                            </span>
+                                                            <!-- not tested -->
+                                                            <span v-else> 
+                                                                <v-btn @click="runTests" slot="activator" color="grey" dark>
+                                                                    <v-icon>fas fa-question</v-icon> Not tested
+                                                                </v-btn>
+                                                            </span>
+                                                        </v-flex>
+                                                    </v-layout>
+                                                    
+                                                    <!-- SPEAKER -->
+                                                    <v-layout row wrap justify-center>
+                                                        <!-- switch -->
+                                                        <v-flex xs12 offset-md2 md5>
+                                                            <v-switch label="Speaker" value="speaker" v-model="checkedTests" color="#f45525">
+                                                            </v-switch>
+                                                        </v-flex>
+                                                        <!-- button state -->
+                                                        <v-flex xs12 md4>
+                                                            <span v-if="cb.logs.test != null && cb.logs.test.speaker != 0"> 
+                                                                <!-- passed -->
+                                                                <span v-if="cb.logs.test.speaker== 1"> 
+                                                                    <v-btn @click="runTests" slot="activator" color="green" dark>
+                                                                        <v-icon>fas fa-check</v-icon> Passed
+                                                                    </v-btn>
+                                                                </span>
+                                                                <!-- failed -->
+                                                                <span v-else> 
+                                                                    <v-btn @click="runTests" slot="activator" color="red" dark>
+                                                                        <v-icon>fas fa-times</v-icon> Failed
+                                                                    </v-btn>
+                                                                </span>
+                                                            </span>
+                                                            <!-- not tested -->
+                                                            <span v-else> 
+                                                                <v-btn @click="runTests" slot="activator" color="grey" dark>
+                                                                    <v-icon>fas fa-question</v-icon> Not tested
+                                                                </v-btn>
+                                                            </span>
+                                                        </v-flex>
+                                                    </v-layout>
+                                                    
+                                                    <!-- OCR -->
+                                                    <v-layout row wrap justify-center>
+                                                        <!-- switch -->
+                                                        <v-flex xs12 offset-md2 md5>
+                                                            <v-switch label="OCR" value="ocr" v-model="checkedTests" color="#f45525">
+                                                            </v-switch>
+                                                        </v-flex>
+                                                        <!-- button state -->
+                                                        <v-flex xs12 md4>
+                                                            <span v-if="cb.logs.test != null && cb.logs.test.ocr != 0"> 
+                                                                <!-- passed -->
+                                                                <span v-if="cb.logs.test.ocr== 1"> 
+                                                                    <v-btn @click="runTests" slot="activator" color="green" dark>
+                                                                        <v-icon>fas fa-check</v-icon> Passed
+                                                                    </v-btn>
+                                                                </span>
+                                                                <!-- failed -->
+                                                                <span v-else> 
+                                                                    <v-btn @click="runTests" slot="activator" color="red" dark>
+                                                                        <v-icon>fas fa-times</v-icon> Failed
+                                                                    </v-btn>
+                                                                </span>
+                                                            </span>
+                                                            <!-- not tested -->
+                                                            <span v-else> 
+                                                                <v-btn @click="runTests" slot="activator" color="grey" dark>
+                                                                    <v-icon>fas fa-question</v-icon> Not tested
+                                                                </v-btn>
+                                                            </span>
+                                                        </v-flex>
+                                                    </v-layout>
+                                                    
+                                                    <!-- DEBUG 
+                                                        <span>Checked names: {{ checkedTests }}</span>
+                                                    -->
                                                 </div>
                                                 <br>
                                                 <div class="text-xs-center">
-                                                    <v-btn @click="runTests" slot="activator" color="error" dark>
+                                                    
+                                                    <v-btn v-if="!cb.logs.runningTest"
+                                                           block
+                                                           @click="runTests"
+                                                           slot="activator" 
+                                                           color="error" 
+                                                           dark>
                                                         <v-icon>fas fa-share-square</v-icon> Run tests
                                                     </v-btn>
+                                                    <v-btn v-else
+                                                           block
+                                                           disabled>
+                                                        <v-icon>fas fa-share-square</v-icon> Running tests...
+                                                    </v-btn>
+                                                    <!-- DEBUG
+                                                       Running test: {{ cb.logs.runningTest }}
+                                                    -->
                                                 </div>
                                             </div>
                                             
@@ -365,11 +504,14 @@ export default {
         runTests() {
 			let axios = this.$axios
 			let CB = this.CB
-			axios.post(CB + '/testCoderbot', { params: { varargin: this.checkedTests } })
+            this.cb.logs.runningTest = true
+			axios.post(CB + '/testCoderbot', { params: this.checkedTests })
 				.then(function(response) {
+                    this.cb.logs.test = response.data
 					this.snackText = 'Running tests'
 					this.snackbar = true
 					this.prepopulate()
+                    this.cb.logs.runningTest = false
 				}.bind(this))
 		},
 		restore() {
@@ -657,13 +799,15 @@ export default {
                     motors: null
 				},
 				logs: {
-					log: null
+					log: null,
+                    test: null,
+                    runningTest: false
 				}
 			},
 			drawer: null,
 			tab: null,
 			//tabs: ['Generali', 'Rete', 'Movimento', 'Suoni', 'Avanzate'],
-			tabs: ['Generali', 'Movimento', 'Suoni', 'Avanzate', 'Test'],
+			tabs: ['Generali', 'Movimento', 'Suoni', 'Avanzate', 'Test']
 		}
 	}
 }
@@ -683,5 +827,4 @@ export default {
 	margin-right: 7px;
 	text-size: 10px;
 }
-
 </style>

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -267,16 +267,18 @@
                                             
 											<div class="cardContent">
 												<div id='test_array'>
-                                                        <v-switch label="Motors" value="motors" v-model="checkedTests"></v-switch>
-                                                        <v-switch label="Sonar" value="sonar" v-model="checkedTests"></v-switch>
-                                                        <v-switch label="Speaker" value="speaker" v-model="checkedTests"></v-switch>
-                                                        <v-switch label="OCR" value="ocr" v-model="checkedTests"></v-switch>
+                                                        <v-switch label="Motors" value="motors" v-model="checkedTests" color="#f45525"></v-switch>
+                                                        <v-switch label="Sonar" value="sonar" v-model="checkedTests" color="#f45525"></v-switch>
+                                                        <v-switch label="Speaker" value="speaker" v-model="checkedTests" color="#f45525"></v-switch>
+                                                        <v-switch label="OCR" value="ocr" v-model="checkedTests" color="#f45525"></v-switch>
                                                     <span>Checked names: {{ checkedTests }}</span>
                                                 </div>
                                                 <br>
+                                                <div class="text-xs-center">
                                                     <v-btn @click="runTests" slot="activator" color="error" dark>
                                                         <v-icon>fas fa-share-square</v-icon> Run tests
                                                     </v-btn>
+                                                </div>
                                             </div>
                                             
                                         </v-card>

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -26,7 +26,7 @@
 				</v-tabs>
 			</v-toolbar>
 			<v-content>
-				<template v-if="status == 200">
+				<!--<template v-if="status == 200">-->
 					<v-tabs-items v-model="tab">
 						<v-tab-item>
 							<v-container grid-list-md text-xs-center>
@@ -257,13 +257,40 @@
 								</v-layout>
 							</v-container>
 						</v-tab-item>
+                        <!-- TEST TAB -->
+                        <v-tab-item>
+							<v-container grid-list-md text-xs-center>
+								<v-layout row wrap align-center>
+									<v-flex xs12 md6 offset-md3>
+										<h3 class="text-xs-left">COMPONENTS TESTS</h3>
+										<v-card>
+                                            
+											<div class="cardContent">
+												<div id='test_array'>
+                                                        <v-switch label="Motors" value="motors" v-model="checkedTests"></v-switch>
+                                                        <v-switch label="Sonar" value="sonar" v-model="checkedTests"></v-switch>
+                                                        <v-switch label="Speaker" value="speaker" v-model="checkedTests"></v-switch>
+                                                        <v-switch label="OCR" value="ocr" v-model="checkedTests"></v-switch>
+                                                    <span>Checked names: {{ checkedTests }}</span>
+                                                </div>
+                                                <br>
+                                                    <v-btn @click="runTests" slot="activator" color="error" dark>
+                                                        <v-icon>fas fa-share-square</v-icon> Run tests
+                                                    </v-btn>
+                                            </div>
+                                            
+                                        </v-card>
+									</v-flex>
+								</v-layout>
+							</v-container>
+						</v-tab-item>
 					</v-tabs-items>
-				</template>
+				<!--</template>
 				<template v-else>
 					<br>
 					In attesa che CoderBot torni online...<br>
 					<v-icon large>signal_wifi_off</v-icon>
-				</template>
+				</template>-->
 			</v-content>
 			<!-- Notification Snackbar -->
 			<v-snackbar v-model="snackbar">
@@ -275,6 +302,7 @@
 		</v-app>
 	</div>
 </template>
+
 <script>
 import sidebar from "../components/Sidebar"
 
@@ -328,6 +356,16 @@ export default {
 			axios.post(CB + '/restoreSettings')
 				.then(function(response) {
 					this.snackText = 'Impostazioni ripristinate'
+					this.snackbar = true
+					this.prepopulate()
+				}.bind(this))
+		},
+        runTests() {
+			let axios = this.$axios
+			let CB = this.CB
+			axios.post(CB + '/testCoderbot', { params: { varargin: this.checkedTests } })
+				.then(function(response) {
+					this.snackText = 'Running tests'
 					this.snackbar = true
 					this.prepopulate()
 				}.bind(this))
@@ -564,6 +602,7 @@ export default {
 			fileUrl: '',
 			counter: 0,
 			updateStatusText: '',
+            checkedTests: [], // checked test array
 			updateStatus: 0,
 			// TODO: Prepopulate this
 			settings: {
@@ -622,7 +661,7 @@ export default {
 			drawer: null,
 			tab: null,
 			//tabs: ['Generali', 'Rete', 'Movimento', 'Suoni', 'Avanzate'],
-			tabs: ['Generali', 'Movimento', 'Suoni', 'Avanzate'],
+			tabs: ['Generali', 'Movimento', 'Suoni', 'Avanzate', 'Test'],
 		}
 	}
 }

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -612,7 +612,8 @@ export default {
 					cbVersion: null,
 					backendVersion: null,
 					vueVersion: null,
-					kernel: null
+					kernel: null,
+                    motors: null
 				},
 				logs: {
 					log: null

--- a/static/js/blockly/it.js
+++ b/static/js/blockly/it.js
@@ -281,6 +281,7 @@ Blockly.Msg["MATH_TRIG_TOOLTIP_ATAN"] = "Restituisce l'arco-tangente di un numer
 Blockly.Msg["MATH_TRIG_TOOLTIP_COS"] = "Restituisce il coseno di un angolo espresso in gradi (non radianti).";
 Blockly.Msg["MATH_TRIG_TOOLTIP_SIN"] = "Restituisce il seno di un angolo espresso in gradi (non radianti).";
 Blockly.Msg["MATH_TRIG_TOOLTIP_TAN"] = "Restituisce la tangente di un angolo espresso in gradi (non radianti).";
+Blockly.Msg["MEASURE_UNIT"] = "millimetri"
 Blockly.Msg["NEW_VARIABLE"] = "Crea variabile...";
 Blockly.Msg["NEW_VARIABLE_TITLE"] = "Nome della nuova variabile:";
 Blockly.Msg["ORDINAL_NUMBER_SUFFIX"] = "";  // untranslated


### PR DESCRIPTION
CoderBot front-end can now control rotary encoders mounted on new type of CoderBot.
New hardware test can now be launched from the settings menu in order to check for hardware failure
**Compatibility with older version has been preserved.**